### PR TITLE
Fixes for LLVM-2.9 

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,11 +1,11 @@
 CXXFLAGS := $(shell llvm-config --cxxflags)
 LLVMLDFLAGS := $(shell llvm-config --ldflags --libs)
+DDD := $(shell echo $(LLVMLDFLAGS))
 SOURCES = tutorial1.cpp \
     tutorial2.cpp \
     tutorial3.cpp \
     tutorial4.cpp \
-    tutorial6.cpp \
-	tutorial7.cpp
+    tutorial6.cpp 
 OBJECTS = $(SOURCES:.cpp=.o)
 EXES = $(OBJECTS:.o=)
 CLANGLIBS = -lclangParse \
@@ -16,7 +16,6 @@ CLANGLIBS = -lclangParse \
 	-lclangLex \
 	-lclangBasic \
 	-lLLVMSupport \
-	-lLLVMSystem \
 
 all: $(OBJECTS) $(EXES)
 

--- a/tutorial1.cpp
+++ b/tutorial1.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/System/Host.h"
+#include "llvm/Support/Host.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 
 #include "clang/Frontend/DiagnosticOptions.h"
@@ -37,7 +37,7 @@ int main()
 	clang::LangOptions languageOptions;
 	clang::FileSystemOptions fileSystemOptions;
 	clang::FileManager fileManager(fileSystemOptions);
-
+\
 	clang::SourceManager sourceManager(
         diagnostic,
         fileManager);

--- a/tutorial2.cpp
+++ b/tutorial2.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/System/Host.h"
+#include "llvm/Support/Host.h"
 
 #include "clang/Frontend/DiagnosticOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"

--- a/tutorial3.cpp
+++ b/tutorial3.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/System/Host.h"
+#include "llvm/Support/Host.h"
 
 #include "clang/Frontend/DiagnosticOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"

--- a/tutorial4.cpp
+++ b/tutorial4.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/System/Host.h"
+#include "llvm/Support/Host.h"
 
 #include "clang/Frontend/DiagnosticOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"

--- a/tutorial6.cpp
+++ b/tutorial6.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/System/Host.h"
+#include "llvm/Support/Host.h"
 
 #include "clang/Frontend/DiagnosticOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"


### PR DESCRIPTION
Hey,
I have fixed the tutorials to use Support/Host.c instead of the older System/Host.c
I also fixed the Makefile to remove the unwanted dependency on -lLLVMSystem that doesn't exist any more.

Please pull the changes so that others can benefit from them too!
