### PR TITLE
Fix build - clang trunk on RHEL6

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,7 @@
 LLVMCOMPONENTS := backend
-CXXFLAGS := $(shell llvm-config --cxxflags)
+RTTIFLAG := -fno-rtti
+#RTTIFLAG :=
+CXXFLAGS := $(shell llvm-config --cxxflags) $(RTTIFLAG)
 LLVMLDFLAGS := $(shell llvm-config --ldflags --libs $(LLVMCOMPONENTS))
 DDD := $(shell echo $(LLVMLDFLAGS))
 SOURCES = tutorial1.cpp \


### PR DESCRIPTION
Two small changes:
rather than link against every possible LLVM library, link against only the backend libraries. (Otherwise you link against libraries for targets that aren't built.)
disable rtti - since rtti is apparently disabled by default in building clang, example 6 wouldn't link for me without this flag.

I don't think this would break any earlier versions of clang, but I haven't tested.
