### PR TITLE
Fix libraries link order

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,17 +11,17 @@ SOURCES = tutorial1.cpp \
     tutorial6.cpp 
 OBJECTS = $(SOURCES:.cpp=.o)
 EXES = $(OBJECTS:.o=)
-CLANGLIBS = -lclangParse \
-    -lclangSerialization \
-    -lclangDriver \
+CLANGLIBS = \
+    -lclangFrontend \
+    -lclangParse \
     -lclangSema \
     -lclangAnalysis \
     -lclangAST \
-	-lclangFrontend \
-	-lclangLex \
-    -lLLVMMC \
-	-lclangBasic \
-	-lLLVMSupport \
+    -lclangLex \
+    -lclangBasic \
+    -lclangDriver \
+    -lclangSerialization \
+
 
 all: $(OBJECTS) $(EXES)
 


### PR DESCRIPTION
This order is the one that works on my system (Arch Linux with CLang 3.0). If this also works on Ubuntu (which I think it should), I suggest you use this order.
