### PR TITLE
makefile adjustments for non standard LLVM path

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 CXX := clang++
 LLVMCOMPONENTS := cppbackend
 RTTIFLAG := -fno-rtti
-LLVMCONFIG := /Users/luca/Documents/src/llvm/build/Release/bin/llvm-config
+LLVMCONFIG := ~/Documents/src/llvm/build/Release/bin/llvm-config
 
 CXXFLAGS := -I$(shell $(LLVMCONFIG) --src-root)/tools/clang/include -I$(shell $(LLVMCONFIG) --obj-root)/tools/clang/include $(shell $(LLVMCONFIG) --cxxflags) $(RTTIFLAG)
 LLVMLDFLAGS := $(shell $(LLVMCONFIG) --ldflags --libs $(LLVMCOMPONENTS))


### PR DESCRIPTION
I modified makefile to handle situations where LLVM is not installed system wide (e.g. only compiled from source). The changes are only inside makefile, and includes a line that is not so general (line 4 of makefile) that specifies my location of llvm-config. When merging, this line can be left as is in the original sources, since it must be changed with real llvm-config path
