### PR TITLE
llvm-config var in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -43,7 +43,7 @@ CLANGLIBS = \
 				-lclangAST\
 				-lclangLex\
 				-lclangBasic\
-				$(shell llvm-config --libs)
+				$(shell $(LLVMCONFIG) --libs)
 
 all: $(OBJECTS) $(EXES)
 


### PR DESCRIPTION
Hi,

this commit uses modifies the makefile and avoids a naked use of llvm-config.
Instead of llvm-config we are using the LLVMCONFIG variable now.

Cheers!

e3
