### PR TITLE
The pointer updated to use std::shared_ptr<T>.

### DIFF
--- a/CItutorial1.cpp
+++ b/CItutorial1.cpp
@@ -30,10 +30,10 @@ int main()
     CompilerInstance ci;
     ci.createDiagnostics();
 
-    llvm::IntrusiveRefCntPtr<TargetOptions> pto( new TargetOptions());
-    pto->Triple = llvm::sys::getDefaultTargetTriple();
-    TargetInfo *pti = TargetInfo::CreateTargetInfo(ci.getDiagnostics(), pto.getPtr());
-    ci.setTarget(pti);
+ 	std::shared_ptr<TargetOptions>	pto	=	std::make_shared<TargetOptions>();
+	pto->Triple = llvm::sys::getDefaultTargetTriple();
+	TargetInfo *pti = TargetInfo::CreateTargetInfo(ci.getDiagnostics(), pto);
+	ci.setTarget(pti);
 
     ci.createFileManager();
     ci.createSourceManager(ci.getFileManager());


### PR DESCRIPTION
LLVM 3.5 header uses `std::shared_ptr<T>` instead of `llvm::IntrusiveRefCntPtr`.
I am not sure how you want to follow these changes, but I hope you to consider my patch.